### PR TITLE
Increased pkgrel version to trigger rebuild

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-compressed-depth-image-transport
 	pkgdesc = ROS - Compressed_depth_image_transport provides a plugin to image_transport for transparently sending depth images (raw, floating-point) using PNG compression.
 	pkgver = 1.9.5
-	pkgrel = 3
+	pkgrel = 4
 	url = https://www.wiki.ros.org/image_transport_plugins
 	arch = any
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname='ros-melodic-compressed-depth-image-transport'
 pkgver='1.9.5'
 _pkgver_patch=0
 arch=('any')
-pkgrel=3
+pkgrel=4
 license=('BSD')
 
 ros_makedepends=(


### PR DESCRIPTION
As the opencv libraries got updated in the meantime we have to trigger a rebuild.

@bionade24 is that the way to go in such a situation? When building from the aur packages directly, I used the helper script as [described in the arch wiki](https://wiki.archlinux.org/index.php/ROS#Rebuild_when_shared_libraries_are_updated), but when using a binary installation binary packages have to be rebuilt / relinked. From my understanding increasing the pkgrel number is the correct way to express this, is this correct?

 If so, I'll update other packages accordingly.